### PR TITLE
feat:implemented kafka pub for user handler

### DIFF
--- a/handlers/users.go
+++ b/handlers/users.go
@@ -59,6 +59,10 @@ func (u Users) UserSignUp(data model.UserSignUp) error {
 		Password:        hashPassword,
 		ConfirmPassword: hashConfirmPassword,
 	}
+	if err := u.pub.SendMessage("verify-email", []byte("user-email"), []byte(rec.Email)); err != nil {
+		return fmt.Errorf("error publishing user email")
+	}
+
 	if err := u.store.CreateUser(rec); err != nil {
 		return fmt.Errorf("error creating user %v", err)
 	}


### PR DESCRIPTION
Integrate kakify publish(pub) into user handler, enabling the password change feature  to publish message to kakify .This allows the notify service to subscribe and respond to password change events effectively.